### PR TITLE
feat : 리뷰 이미지 삽입, 삭제 기능 추가 ( #2 )

### DIFF
--- a/re-place/src/main/java/com/replace/re/place/image/dao/ImageDao.java
+++ b/re-place/src/main/java/com/replace/re/place/image/dao/ImageDao.java
@@ -1,0 +1,150 @@
+package com.replace.re.place.image.dao;
+
+import com.replace.re.place.image.dto.ImageDto;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+public class ImageDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ImageDao(DataSource dataSource){
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+
+    class ImageRowMapper implements RowMapper<ImageDto>{
+
+        @Override
+        public ImageDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+            ImageDto imageDto = new ImageDto(
+                    rs.getLong("image_id"),
+                    rs.getString("url"),
+                    rs.getTimestamp("created_at").toLocalDateTime(),
+                    rs.getTimestamp("updated_at").toLocalDateTime()
+            );
+            return imageDto;
+        }
+    }
+
+
+    // 어느 한 리뷰에 속하는 이미지 목록을 반환하는 메서드
+    public List<ImageDto> getReviewImagesByReviewId(Long reviewId){
+        String query = "select * from image where image_id in (select image_id from review_image where review_id = ?)";
+
+        return this.jdbcTemplate.query(query, new ImageRowMapper(), reviewId);
+    }
+
+    // Image 테이블에서 pk인 image_id로 행을 조회.
+    public ImageDto getImageByImageId(Long imageId){
+        String query = "select * from image where image_id = ?";
+
+        return this.jdbcTemplate.queryForObject(query, new ImageRowMapper(), imageId);
+    }
+
+
+    // Image 테이블에 새로운 행 insert.
+    public Long insertImage(String url){
+        String query = "insert into image(url) values(?)";
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        this.jdbcTemplate.update(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
+                PreparedStatement pstmt = con.prepareStatement(query, new String[]{"image_id"});
+                pstmt.setString(1, url);
+
+                return pstmt;
+            }
+        }, keyHolder);
+
+        Number key = keyHolder.getKey();
+        Long imageId = key.longValue();
+
+        return imageId;
+    }
+
+    // Image 테이블에서 pk인 image_id로 행 삭제.
+    public void deleteImageByImageId(Long imageId){
+        String query = "delete from image where image_id = ?";
+
+        this.jdbcTemplate.update(query, imageId);
+    }
+
+    // Review_Image 테이블에서 review_id를 가지고 해당되는 행들의 image_id를 찾아 Image 테이블에서 삭제.
+    public void deleteImageByReviewId(Long reviewId){
+        String query = "delete from image where image_id in (select image_id from review_image where review_id = ?)";
+
+        this.jdbcTemplate.update(query, reviewId);
+    }
+
+    // Review_Image 테이블에 행 insert
+    public Long insertReivewImage(Long reviewId, Long imageId){
+        String query = "insert into review_image(review_id, image_id) values(?, ?)";
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        this.jdbcTemplate.update(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection con) throws SQLException {
+                PreparedStatement pstmt = con.prepareStatement(query, new String[]{"review_image_id"});
+                pstmt.setLong(1, reviewId);
+                pstmt.setLong(2, imageId);
+
+                return pstmt;
+            }
+        }, keyHolder);
+
+        Number key = keyHolder.getKey();
+        Long reviewImageId = key.longValue();
+
+        return reviewImageId;
+    }
+
+    // Review_Image테이블에서 pk인 review_image_id로 행을 식별하여 삭제.
+    public void deleteReviewImageByReviewImageId(Long reviewImageId){
+        String query = "delete from review_image where review_image_id = ?";
+
+        this.jdbcTemplate.update(query, reviewImageId);
+    }
+
+
+    // Review_Image테이블에서 fk인 review_id로 행을 식별하여 삭제.
+    public void deleteReviewImageByReviewId(Long reviewId){
+        String query = "delete from review_image where review_id = ?";
+
+        this.jdbcTemplate.update(query, reviewId);
+    }
+
+    // Review Image 테이블에서 fk인 review_id를 가지는 행이 존재하는지 여부를 리턴.
+    public Boolean checkReviewImageExist(Long reviewId){
+
+        String query = "select if(exists(select * from review_image where review_id = ?), 1, 0)";
+
+        return this.jdbcTemplate.queryForObject(query, Integer.class, reviewId) == 1;
+    }
+
+    // Image 테이블에서 pk인 image_id를 가지는 행이 존재하는지 여부를 리턴.
+    public Boolean checkImageExist(Long imageId){
+        String query = "select if(exists(select * from image where image_id = ?), 1, 0)";
+
+        return this.jdbcTemplate.queryForObject(query, Integer.class, imageId) == 1;
+    }
+}

--- a/re-place/src/main/java/com/replace/re/place/image/dto/ImageDto.java
+++ b/re-place/src/main/java/com/replace/re/place/image/dto/ImageDto.java
@@ -1,0 +1,20 @@
+package com.replace.re.place.image.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageDto {
+    private Long imageId;
+    private String url;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ImageDto(String url){
+        this.url = url;
+    }
+}

--- a/re-place/src/main/java/com/replace/re/place/image/dto/ReviewImageDto.java
+++ b/re-place/src/main/java/com/replace/re/place/image/dto/ReviewImageDto.java
@@ -1,0 +1,22 @@
+package com.replace.re.place.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewImageDto {
+
+    private Long reviewImageId;
+    private Long reviewId;
+    private Long imageId;
+
+    public ReviewImageDto(Long reviewId, Long imageId){
+        this.reviewId = reviewId;
+        this.imageId = imageId;
+    }
+}

--- a/re-place/src/main/java/com/replace/re/place/image/service/ImageService.java
+++ b/re-place/src/main/java/com/replace/re/place/image/service/ImageService.java
@@ -1,13 +1,19 @@
 package com.replace.re.place.image.service;
 
+import com.replace.re.place.image.dao.ImageDao;
+import com.replace.re.place.image.dto.ImageDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class ImageService {
 
+    private final ImageDao imageDao;
 
     /*
     이미지 저장은 AWS s3를 사용하기로 되어 있지만, 아직 S3 버킷을 생성하지 않아 임시로 이미지를 반환하는 코드를 구현.
@@ -17,5 +23,41 @@ public class ImageService {
         images.add("https://via.placeholder.com/300x200.png?text=Sample+Image");
 
         return images;
+    }
+
+    public List<ImageDto> getReviewImagesByReviewId(Long reviewId){
+        return imageDao.getReviewImagesByReviewId(reviewId);
+    }
+
+
+    // 이미지 개수, 크기 등의 제한은 컨트롤러 또는 클라이언트 단에서 처리해야할 것.
+    public Boolean insertReviewImage(Long reviewId, List<String> imageUrls){
+
+        // 리뷰가 존재하는지에 대한 검증이 필요할 것.
+
+
+        for(String imageUrl : imageUrls){
+
+            Long imageId = imageDao.insertImage(imageUrl);
+
+            Long reviewImageId = imageDao.insertReivewImage(reviewId, imageId);
+        }
+
+        return true;
+    }
+
+
+    public void deleteReviewImage(Long reviewId){
+        if(imageDao.checkReviewImageExist(reviewId)){
+            List<ImageDto> reviewImageDtos = imageDao.getReviewImagesByReviewId(reviewId);
+
+            imageDao.deleteReviewImageByReviewId(reviewId);
+
+            Iterator<ImageDto> it = reviewImageDtos.iterator();
+            while(it.hasNext()){
+                ImageDto imageDto = it.next();
+                imageDao.deleteImageByImageId(imageDto.getImageId());
+            }
+        }
     }
 }

--- a/re-place/src/test/java/com/replace/re/place/image/service/ImageServiceTest.java
+++ b/re-place/src/test/java/com/replace/re/place/image/service/ImageServiceTest.java
@@ -1,0 +1,75 @@
+package com.replace.re.place.image.service;
+
+import com.replace.re.place.image.dto.ImageDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ImageServiceTest {
+
+    @Autowired
+    private ImageService imageService;
+
+
+    @Test
+    @DisplayName("리뷰 이미지 INSERT 테스트")
+    @Transactional
+    public void reviewImageInsertTest(){
+
+        List<String> imageUrls = new ArrayList<>();
+
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image1");
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image2");
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image3");
+
+        Boolean isSuccess = imageService.insertReviewImage(1L, imageUrls);
+
+        List<ImageDto> imageDtos = imageService.getReviewImagesByReviewId(1L);
+
+        List<String> imageDtosUrls = new ArrayList<>();
+
+        Iterator<ImageDto> it = imageDtos.iterator();
+        while(it.hasNext()){
+            ImageDto imageDto = it.next();
+
+            imageDtosUrls.add(imageDto.getUrl());
+        }
+
+        Collections.sort(imageDtosUrls);
+
+        assertEquals(imageUrls, imageDtosUrls);
+    }
+
+
+    @Test
+    @DisplayName("리뷰 이미지 DELETE 테스트")
+    @Transactional
+    public void reviewImageDeleteTest(){
+
+        List<String> imageUrls = new ArrayList<>();
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image1");
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image2");
+        imageUrls.add("https://via.placeholder.com/300x200.png?text=Sample+Image3");
+
+        Boolean isSuccess = imageService.insertReviewImage(1L, imageUrls);
+
+        imageService.deleteReviewImage(1L);
+
+        List<ImageDto> imageDtos = imageService.getReviewImagesByReviewId(100L);
+
+        assertEquals(imageDtos.size(), 0);
+
+    }
+}


### PR DESCRIPTION
이미지만을 다루는 Image 도메인을 추가하였습니다. 이미지 삽입, 삭제, 조회 등의 기능들은 Image 도메인 내에서 구현하도록 합니다.

단독으로 이미지를 다루는 컨트롤러의 API는 계획에 없기 때문에, Repository, Service 까지만 구현하였습니다. 

리뷰 이미지를 다루기 위해서 Review 도메인 내에서 Image 도메인의 메서드를 호출하여 사용하겠습니다.